### PR TITLE
Expose LinearSolverBackend::set_timeout

### DIFF
--- a/python/pylp.cpp
+++ b/python/pylp.cpp
@@ -184,6 +184,7 @@ BOOST_PYTHON_MODULE(pylp) {
 			.def("initialize", static_cast<void(LinearSolverBackend::*)(unsigned int, VariableType, const std::map<unsigned int, VariableType>&)>(&LinearSolverBackend::initialize))
 			.def("set_objective", static_cast<void(LinearSolverBackend::*)(const LinearObjective&)>(&LinearSolverBackend::setObjective))
 			.def("set_constraints", &LinearSolverBackend::setConstraints)
+			.def("set_timeout", &LinearSolverBackend::setTimeout)
 			.def("solve", &solve)
 			;
 	boost::python::register_ptr_to_python<std::shared_ptr<LinearSolverBackend>>();


### PR DESCRIPTION
It's a little change that looks big now because somehow the tabs were not equal to 4 spaces before and my change was not displayed correctly so I did a retab on top of it. Also it turns out all backends have a `setTimeout` method such that the only thing left to do was exposing the method in the LinearSolverBackend via `.def("set_timeout", &LinearSolverBackend::setTimeout) `