### PR TITLE
add stubs to turn on/off verbose logging in solver backend

### DIFF
--- a/pylp/decl.pxd
+++ b/pylp/decl.pxd
@@ -100,6 +100,7 @@ cdef extern from 'impl/solvers/LinearSolverBackend.h':
         void setTimeout(double)
         void setOptimalityGap(double, bool)
         void setNumThreads(unsigned int)
+        void setVerbose(bool)
         bool solve(Solution& solution, string& message)
 
 cdef extern from 'impl/solvers/QuadraticSolverBackend.h':

--- a/pylp/wrapper.pyx
+++ b/pylp/wrapper.pyx
@@ -220,6 +220,9 @@ cdef class LinearSolver:
     def set_num_threads(self, num_threads):
         deref(self.p).setNumThreads(num_threads)
 
+    def set_verbose(self, verbose):
+        deref(self.p).setVerbose(verbose)
+
     def solve(self):
         solution = Solution(self.num_variables)
         cdef string message


### PR DESCRIPTION
the setVerbose function already exists in the solver backends, but is not exposed to the python frontend.

@funkey 